### PR TITLE
Remove call to decode_escapes() as it breaks non-ASCII text

### DIFF
--- a/shortcodes.py
+++ b/shortcodes.py
@@ -32,11 +32,6 @@ def register(tag, end_tag=None):
     return register_function
 
 
-# Decode unicode escape sequences in a string.
-def decode_escapes(s):
-    return bytes(s, 'utf-8').decode('unicode_escape')
-
-
 # --------------------------------------------------------------------------
 # Exception classes.
 # --------------------------------------------------------------------------
@@ -118,8 +113,6 @@ class Shortcode(Node):
             if match.group(2) or match.group(5):
                 key = match.group(1) or match.group(5)
                 value = match.group(3) or match.group(4) or match.group(6)
-                if match.group(3) or match.group(4):
-                    value = decode_escapes(value)
                 if key:
                     kwargs[key] = value
                 else:

--- a/test_shortcodes.py
+++ b/test_shortcodes.py
@@ -186,3 +186,13 @@ def test_unbalanced_tags_exception():
     text = '[% wrap %] missing end tag...'
     with pytest.raises(shortcodes.NestingError):
         shortcodes.Parser().parse(text)
+
+
+# --------------------------------------------------------------------------
+# Test non-ASCII text.
+# --------------------------------------------------------------------------
+
+def test_nonascii_args():
+    text = '[% args pøs0 k€¥="välué" %]'
+    rendered = shortcodes.Parser().parse(text)
+    assert rendered == 'pøs0|k€¥:välué'


### PR DESCRIPTION
The decode_escapes() function implemented functionality that is not documented, not tested, and breaks non-ASCII text, so I removed it. Everything seems to work just fine now.

This fixes issue #6.
