### PR TITLE
migrate to shlex.split from regex based parsing and add option to use either only pargs or only kwargs

### DIFF
--- a/shortcodes.py
+++ b/shortcodes.py
@@ -84,7 +84,7 @@ class Shortcode(Node):
         parsed_args = shlex.split(argstring)
         for arg in parsed_args:
             if self.allow_kwargs and '=' in arg:
-                key, value = arg.split('=')
+                key, value = arg.split('=', 1)
                 kwargs[key] = value
             else:
                 if not self.allow_pargs:

--- a/test_shortcodes.py
+++ b/test_shortcodes.py
@@ -132,6 +132,18 @@ def test_wrapping_and_text_mix():
     assert rendered == '<div>..<p>.bar.</p>..</div>'
 
 
+def test_only_kwargs():
+    parser = shortcodes.Parser()
+    parser.register(lambda pargs, kwargs, context: f"{kwargs}", 'onlykwargs', allow_pargs=False)
+    assert parser.parse("[%onlykwargs key=value %]")
+
+
+def test_only_pargs():
+    parser = shortcodes.Parser()
+    parser.register(lambda pargs, kwargs, context: pargs, 'onlypargs', allow_kwargs=False)
+    assert parser.parse("[%onlypargs postion=arg1 position-arg2 %]") == "['postion=arg1', 'position-arg2']"
+
+
 # ------------------------------------------------------------------------------
 # Test context object support.
 # ------------------------------------------------------------------------------
@@ -186,6 +198,18 @@ def test_unbalanced_tags_exception():
     text = '[% wrap %] missing end tag...'
     with pytest.raises(shortcodes.ShortcodeSyntaxError):
         shortcodes.Parser().parse(text)
+
+def test_pargs_not_allowed():
+    parser = shortcodes.Parser()
+    parser.register(lambda pargs, kwargs, context: f"{kwargs}", 'onlykwargs', allow_pargs=False)
+    assert parser.parse("[%onlykwargs key=value %]")
+    with pytest.raises(shortcodes.ShortcodeRenderingError):
+        parser.parse("[%onlykwargs positional-arg %]")
+
+def test_both_pargs_and_kwargs_disabled():
+    parser = shortcodes.Parser()
+    with pytest.raises(shortcodes.ShortcodeError):
+        parser.register(lambda pargs, kwargs, context: f"{kwargs}", 'onlykwargs', allow_pargs=False, allow_kwargs=False)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
python comes with a nifty [shlex.split](https://docs.python.org/3.8/library/shlex.html#shlex.split) function which can be used instead of regex in shortcode argument parsing - this PR migrates to this solution.

Additionally, it adds support for registering only positional argument or only keyword argument shortcodes. Positional argument only shortcodes in the current release do not work as `=` is keyword argument reserved character, i.e. `[% foo http://example.com?foo=bar %]` is breaking - this patch fixes that by allowing to explicit registration of such shortcodes.

Let me know if I messed something up. It's my first time contributing here :)